### PR TITLE
Fix for search input field on search results page

### DIFF
--- a/app/design/frontend/base/default/layout/turpentine_esi.xml
+++ b/app/design/frontend/base/default/layout/turpentine_esi.xml
@@ -177,6 +177,25 @@
         -->
     </catalog_product_compare_index>
 
+    <!-- Catalog Search -->
+
+    <!--
+    If the search input box is inside the header, it needs to contain the current search string after searching.
+    The block below overrules the ESI Options for the header on the search results page.
+    We change the scope of the header to "page", so the current URL is passed to the ESI request.
+    We set the TTL to 0, because the same user is probably not going to search for the same string again.
+    -->
+    <catalogsearch_result_index>
+        <reference name="header">
+            <action method="setEsiOptions">
+                <params>
+                    <access>private</access>
+                    <scope>page</scope>
+                    <ttl>0</ttl>
+                </params>
+            </action>
+        </reference>
+    </catalogsearch_result_index>
 
     <!-- Checkout -->
 


### PR DESCRIPTION
By default the the search input box is inside the header. 
It needs to contain the current search string after searching, on the search results page.
Before this fix, the header ESI block was cached, so this did not work. The search string was wrong or not showing.
