### PR TITLE
Fix: do not insert ESI tag if block is generated by an Ajax request

### DIFF
--- a/app/design/frontend/base/default/template/turpentine/esi.phtml
+++ b/app/design/frontend/base/default/template/turpentine/esi.phtml
@@ -20,19 +20,22 @@
  */
 
 $debugEnabled = (bool)Mage::helper( 'turpentine/esi' )->getEsiDebugEnabled();
+$isAjax = Mage::app()->getRequest()->getParam('is_ajax', false);
 
-if( $debugEnabled ) {
-    echo sprintf( '<!-- ESI START [%s] -->', $this->getNameInLayout() ) . PHP_EOL;
-    echo sprintf( '<!-- ESI URL: %s -->', $this->getEsiUrl() ) . PHP_EOL;
-} else {
-    echo '<!-- ESI START DUMMY COMMENT [] -->' . PHP_EOL;
-    echo '<!-- ESI URL DUMMY COMMENT -->' . PHP_EOL;
-}
-echo sprintf( '<esi:remove>ESI processing not enabled</esi:remove>
+if( !$isAjax ) {
+    if( $debugEnabled ) {
+        echo sprintf( '<!-- ESI START [%s] -->', $this->getNameInLayout() ) . PHP_EOL;
+        echo sprintf( '<!-- ESI URL: %s -->', $this->getEsiUrl() ) . PHP_EOL;
+    } else {
+        echo '<!-- ESI START DUMMY COMMENT [] -->' . PHP_EOL;
+        echo '<!-- ESI URL DUMMY COMMENT -->' . PHP_EOL;
+    }
+    echo sprintf( '<esi:remove>ESI processing not enabled</esi:remove>
 <!--esi <esi:include src="%s" /> -->',
-    $this->getEsiUrl() ) . PHP_EOL;
-if( $debugEnabled ) {
-    echo sprintf( '<!-- ESI END [%s] -->', $this->getNameInLayout() ) . PHP_EOL;
-} else {
-    echo '<!-- ESI END DUMMY COMMENT [] -->' . PHP_EOL;
+        $this->getEsiUrl() ) . PHP_EOL;
+    if( $debugEnabled ) {
+        echo sprintf( '<!-- ESI END [%s] -->', $this->getNameInLayout() ) . PHP_EOL;
+    } else {
+        echo '<!-- ESI END DUMMY COMMENT [] -->' . PHP_EOL;
+    }
 }


### PR DESCRIPTION
This fixes problems with the Amasty Shopby extension because the json_decode() fails when it contains an unprocessed ESI tag.