### PR TITLE
Allow cache hit when no session cookie

### DIFF
--- a/app/code/community/Nexcessnet/Turpentine/Model/Varnish/Configurator/Abstract.php
+++ b/app/code/community/Nexcessnet/Turpentine/Model/Varnish/Configurator/Abstract.php
@@ -438,7 +438,7 @@ EOS;
      */
     protected function _getGenerateSession() {
         return Mage::getStoreConfigFlag('turpentine_varnish/general/vcl_fix')
-            ? 'return (pipe);' : 'call generate_session;';
+            ? '' : 'call generate_session;';
     }
 
 


### PR DESCRIPTION
The VCL fix meant to allow cache hit on first visit (no cookie) but for some reason the VCL code return pipe in this case which is not doing what we expected for first visit performance. Why is it there? I just removed this and it seems to work fine without any side effect so far.